### PR TITLE
Return normal range if nil

### DIFF
--- a/moon/cfc_punt/server/sounder.moon
+++ b/moon/cfc_punt/server/sounder.moon
@@ -11,7 +11,7 @@ CFCPunt.getPhysVolume = (ent) ->
     -- Put it right in the "normal" range if we can't figure it out
     return 30001 unless IsValid phys
 
-    phys\GetVolume!
+    phys\GetVolume! or 30001
 
 CFCPunt.getEntVolume = (ent) ->
     mins, maxes = ent\GetHitBoxBounds 0, 0


### PR DESCRIPTION

https://wiki.facepunch.com/gmod/PhysObj:GetVolume

> Returns the volume in source units³. Or nil if the PhysObj is a generated sphere or box.

